### PR TITLE
Add theme toggle and adjust h1 spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
   <title>Mark Bubel — Senior Product Designer Portfolio</title>
   <meta name="description" content="Portfolio of Mark Bubel, Senior Product Designer. Case studies spanning AI products, search platform handling 3M+ monthly queries, and operational systems redesigned across 33 global sites" />
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+  <script>
+    (function(){var t=localStorage.getItem('theme');if(t==='light'||t==='dark')document.documentElement.classList.add(t);})();
+  </script>
   <link rel="stylesheet" href="style.css">
   <link rel="canonical" href="https://www.markbubel.com/" />
   <meta property="og:type" content="website" />
@@ -63,6 +66,56 @@
             <p class="paragraph-tight">Privacy-first analytics enabled</p>
         </footer>
     </main>
+    <button class="theme-toggle" aria-label="Toggle theme" id="theme-toggle">
+        <!-- Sun icon (light mode) -->
+        <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="display:none">
+            <circle cx="12" cy="12" r="5"/>
+            <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+        </svg>
+        <!-- Moon icon (dark mode) -->
+        <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="display:none">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+        </svg>
+        <!-- System icon (auto mode) -->
+        <svg id="icon-system" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="display:none">
+            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/>
+        </svg>
+    </button>
+
+    <script>
+    (function() {
+        var modes = ['system', 'light', 'dark'];
+        var btn = document.getElementById('theme-toggle');
+        var html = document.documentElement;
+
+        function getMode() {
+            return localStorage.getItem('theme') || 'system';
+        }
+
+        function applyMode(mode) {
+            html.classList.remove('light', 'dark');
+            if (mode === 'light' || mode === 'dark') {
+                html.classList.add(mode);
+            }
+            document.getElementById('icon-sun').style.display = mode === 'light' ? 'block' : 'none';
+            document.getElementById('icon-moon').style.display = mode === 'dark' ? 'block' : 'none';
+            document.getElementById('icon-system').style.display = mode === 'system' ? 'block' : 'none';
+        }
+
+        applyMode(getMode());
+
+        btn.addEventListener('click', function() {
+            var current = getMode();
+            var next = modes[(modes.indexOf(current) + 1) % modes.length];
+            localStorage.setItem('theme', next);
+            applyMode(next);
+        });
+    })();
+    </script>
+
     <!-- 100% privacy-first analytics -->
     <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -86,8 +86,9 @@ ol {
 :root {
     --spacing-xl: 3rem;          /* 48px */ 
     --spacing-large: 2.5rem;    /* 40px */
-    --spacing-medium: 1.25rem; /* 20px */
-    --spacing-small: 0.5rem;  /* 8px */
+    --spacing-medium: 1.25rem;  /* 20px */
+    --spacing-base: 1rem;      /* 16px */
+    --spacing-small: 0.5rem;   /* 8px */
     --spacing-none: 0rem;    /* 0px */
 
     --color-bg: #fff;
@@ -129,6 +130,7 @@ body {
     color: var(--color-text-primary);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+
 }
 
 main {
@@ -141,7 +143,7 @@ h1 {
     font-weight: var(--font-weight-bold);
     line-height: var(--line-height-tight);
     margin-top: var(--spacing-none);
-    margin-bottom: var(--spacing-medium);
+    margin-bottom: var(--spacing-base);
 }
 
 h2 {
@@ -206,13 +208,106 @@ footer {
 }
 
 
+/* Dark mode — applied via class or system preference */
+html.dark body {
+  background-color: #111111;
+  color: #ACACAC;
+}
+
+html.dark a {
+  color: var(--color-accent);
+}
+
+html:not(.light):not(.dark) body {
+  background-color: var(--color-bg);
+  color: var(--color-text-primary);
+}
+
 @media (prefers-color-scheme: dark) {
-  body {
+  html:not(.light):not(.dark) body {
     background-color: #111111;
     color: #ACACAC;
   }
 
-  a {
+  html:not(.light):not(.dark) a {
     color: var(--color-accent);
   }
+}
+
+/* Theme toggle button */
+.theme-toggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.6);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background-color 0.2s ease;
+  z-index: 100;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.theme-toggle svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: var(--color-text-primary);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Dark mode toggle styles */
+html.dark .theme-toggle,
+html:not(.light):not(.dark) .theme-toggle {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+html.dark .theme-toggle:hover,
+html:not(.light):not(.dark) .theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+html.dark .theme-toggle svg {
+  stroke: #ACACAC;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not(.light):not(.dark) .theme-toggle {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  html:not(.light):not(.dark) .theme-toggle:hover {
+    background: rgba(255, 255, 255, 0.18);
+  }
+
+  html:not(.light):not(.dark) .theme-toggle svg {
+    stroke: #ACACAC;
+  }
+}
+
+html.light .theme-toggle {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+html.light .theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+html.light .theme-toggle svg {
+  stroke: var(--color-text-primary);
 }


### PR DESCRIPTION
## Summary
- Add light/dark/system theme toggle button (bottom-right, frosted glass, icon-only)
- Theme persists across sessions via localStorage, defaults to system preference
- Cross-device support: backdrop-filter blur, touch-friendly 40px target, iOS/Safari prefixes
- Add `--spacing-base: 1rem` (16px) token and apply to h1 margin-bottom

## Test plan
- [ ] Verify toggle cycles through system → light → dark modes
- [ ] Confirm theme persists after page reload
- [ ] Test on mobile (iOS Safari, Android Chrome) for touch targets and backdrop blur
- [ ] Check light and dark mode rendering matches original design
- [ ] Verify no flash of wrong theme on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)